### PR TITLE
update desoto.service definition file

### DIFF
--- a/.coreos/desoto.env.dist
+++ b/.coreos/desoto.env.dist
@@ -1,7 +1,10 @@
 # Environment variables for the DeSoto service discovery
 # This corresponds to an etcd entry at /environments/desoto
 
-ETCD_HOSTS=http://172.17.42.1:4001
 DOCKER_HOST=unix:///var/run/docker.sock
 SERVICEDEF_PATH=/publication
-#HOST=8.8.8.8
+
+# These two values are set in the docker run command since their values change
+# depending on the run-time environment. See desoto.service for more details.
+# ETCD_HOSTS=http://172.17.42.1:4001
+# HOST=8.8.8.8

--- a/.coreos/desoto.service
+++ b/.coreos/desoto.service
@@ -9,22 +9,18 @@ Restart=always
 TimeoutStartSec=10 min
 User=core
 KillMode=none
-
 EnvironmentFile=/etc/environment
-
-ExecStartPre=/usr/bin/env bash -c "etcdctl get /environments/%p > '/tmp/%p.env'"
-
+ExecStartPre=/usr/bin/env bash \
+	-c "etcdctl --no-sync get /environments/%p > '/tmp/%p.env' && echo \"ETCD_HOSTS=http://`ifconfig docker0 | awk '/\<inet\>/ { print $2}'`:4001\" >> '/tmp/%p.env'"
 ExecStartPre=-/usr/bin/env docker stop "%p"
 ExecStartPre=-/usr/bin/env docker rm "%p"
-ExecStartPre=/usr/bin/env docker pull christianbladescb/desoto
-
+ExecStartPre=/usr/bin/env docker pull quay.io/cbone/desoto
 ExecStart=/usr/bin/env docker run \
-  --name='%p' \
-  --env-file="/tmp/%p.env" \
-  -e HOST=${COREOS_PRIVATE_IPV4} \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  christianbladescb/desoto
-
+	--name='%p' \
+	--env-file="/tmp/%p.env" \
+	-e HOST=${COREOS_PRIVATE_IPV4} \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	quay.io/cbone/desoto
 ExecStop=-/usr/bin/env docker stop "%p"
 
 [X-Fleet]


### PR DESCRIPTION
docker 1.8.3 and 1.9.1 have sets of default IPs for the docker0
bridge device. This change sets this value in the ETCD_HOSTS
environment variable dynamically so that desoto doesn't break
when docker updates change this default IP.
